### PR TITLE
Update ESLint rules for TypeScript

### DIFF
--- a/typescript.js
+++ b/typescript.js
@@ -28,8 +28,8 @@ module.exports = {
                 'js': 'never',
                 'jsx': 'never',
                 'ts': 'never',
-                'tsx': 'never'
-            }
+                'tsx': 'never',
+            },
         ],
     },
 };

--- a/typescript.js
+++ b/typescript.js
@@ -15,9 +15,21 @@ module.exports = {
         'plugin:@typescript-eslint/eslint-recommended',
         // turns on rules from their TypeScript-specific plugin
         'plugin:@typescript-eslint/recommended',
+        // enables ts/tsx file usage when importing modules
+        'plugin:import/typescript',
     ],
     rules: {
         // Allow TypeScript files to have JSX
         'react/jsx-filename-extension': [WARNING, { 'extensions': ['.ts', '.tsx', '.js', '.jsx'] }],
+        'import/extensions': [
+            'error',
+            'ignorePackages',
+            {
+                'js': 'never',
+                'jsx': 'never',
+                'ts': 'never',
+                'tsx': 'never'
+            }
+        ],
     },
 };


### PR DESCRIPTION
Some of these ESLint rules cause TS/TSX files to improperly report that the imported files don't exist, when they do. This is because it's currently set to `['.js', '.jsx']`.

This PR will adjust the rule (specifically for TypeScript) so it will resolve for TS/TSX modules. 